### PR TITLE
Fix SynthObjectController.load type for element

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1135,7 +1135,7 @@ declare module 'abcjs' {
 	export interface SynthObjectController {
 		disable(isDisabled: boolean): void
 		setTune(visualObj: TuneObject, userAction: boolean, audioParams?: SynthOptions): Promise<SynthInitResponse>
-		load(selector: string, cursorControl?: CursorControl | null, visualOptions?: SynthVisualOptions): void
+		load(selector: Selector, cursorControl?: CursorControl | null, visualOptions?: SynthVisualOptions): void
 		play(): void
 		pause(): void
 		toggleLoop(): void


### PR DESCRIPTION
The element can be either a string or an HTMLElement.